### PR TITLE
Update the GoVersion to one supported by buildpack

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/onsi/grace",
-	"GoVersion": "go1.5",
+	"GoVersion": "go1.8",
 	"Packages": [
 		"./..."
 	],


### PR DESCRIPTION
The Go buildpack only supports Go 1.6 and above.